### PR TITLE
feat: add subscription methods for `exchange rates`

### DIFF
--- a/example/lib/pages/main_page.dart
+++ b/example/lib/pages/main_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter_deriv_api_example/blocs/active_symbols/active_symbols_bl
 import 'package:flutter_deriv_api_example/blocs/available_contracts/available_contracts_bloc.dart';
 import 'package:flutter_deriv_api_example/widgets/active_symbols_widget.dart';
 import 'package:flutter_deriv_api_example/widgets/contracts_type_widget.dart';
+import 'package:flutter_deriv_api_example/widgets/exchange_rate_widget.dart';
 import 'package:flutter_deriv_api_example/widgets/price_proposal_widget.dart';
 
 /// MainPage
@@ -47,6 +48,7 @@ class _MainPageState extends State<MainPage> {
             Expanded(child: ActiveSymbolsWidget()),
             Expanded(child: ContractsTypeWidget()),
             Expanded(flex: 2, child: PriceProposalWidget()),
+            const Expanded(flex: 2, child: ExchangeRateWidget()),
           ],
         ),
       );

--- a/example/lib/widgets/exchange_rate_widget.dart
+++ b/example/lib/widgets/exchange_rate_widget.dart
@@ -1,0 +1,93 @@
+import 'dart:async';
+import 'dart:developer';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_deriv_api/api/response/exchange_rates_response_result.dart';
+import 'package:flutter_deriv_api/api/response/exchange_rates_response_extended.dart';
+import 'package:flutter_deriv_api/basic_api/generated/exchange_rates_send.dart';
+
+/// Test widget for the exchange rates for BTC -> USD.
+class ExchangeRateWidget extends StatefulWidget {
+  /// Test widget for exchange rates for BTC -> USD
+  const ExchangeRateWidget({super.key});
+
+  @override
+  State<ExchangeRateWidget> createState() => _ExchangeRateWidgetState();
+}
+
+class _ExchangeRateWidgetState extends State<ExchangeRateWidget> {
+  double value = 0;
+
+  bool isSubscribed = false;
+  int exchangeUpdateTime = 0;
+  String subscriptionId = '';
+
+  Timer? _refreshingTimer;
+
+  @override
+  Widget build(BuildContext context) => Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          ElevatedButton(
+            onPressed: () =>
+                isSubscribed ? _unsubscribe() : _subscribeUSDtoBTC(),
+            child: isSubscribed
+                ? const Text('Unsubscribe')
+                : const Text('Subscribe to exchange rate'),
+          ),
+          const Text('USD:'),
+          Text(value.toString()),
+          const SizedBox(height: 12),
+          const SizedBox(height: 12),
+          Text(
+            'Last updated after: ${exchangeUpdateTime.toStringAsFixed(2)} seconds',
+          )
+        ],
+      );
+
+  Future<void> _subscribeUSDtoBTC() async {
+    final Stream<ExchangeRatesResponse?> ratesStream =
+        ExchangeRatesResponseExtended.subscribeToExchangeRates(
+            const ExchangeRatesRequest(
+      baseCurrency: 'BTC',
+      targetCurrency: 'USD',
+      subscribe: true,
+    ));
+
+    // ignore: cascade_invocations
+    ratesStream.listen((ExchangeRatesResponse? response) {
+      setState(() {
+        subscriptionId = response!.subscription!.id;
+        isSubscribed = true;
+        value = response.exchangeRates!.rates!['USD'] as double;
+        _resetTimer();
+      });
+    });
+  }
+
+  void _resetTimer() {
+    _refreshingTimer?.cancel();
+
+    _refreshingTimer = Timer.periodic(
+      const Duration(seconds: 1),
+      (Timer timer) {
+        exchangeUpdateTime = timer.tick;
+      },
+    );
+  }
+
+  Future<void> _unsubscribe() async {
+    try {
+      final bool $ =
+          await ExchangeRatesResponseExtended.unsubscribeFromExchangeRates(
+              subscriptionId);
+      $.toString();
+      _refreshingTimer?.cancel();
+    } on Exception catch (e) {
+      log(e.toString());
+    }
+    setState(() {
+      isSubscribed = false;
+    });
+  }
+}

--- a/lib/api/response/exchange_rates_response_extended.dart
+++ b/lib/api/response/exchange_rates_response_extended.dart
@@ -31,10 +31,12 @@ class ExchangeRatesResponseExtended extends ExchangeRatesResponse {
                 BaseAPIException(baseExceptionModel: baseExceptionModel),
           );
 
-          return response is ExchangeRatesReceive
-              ? ExchangeRatesResponse.fromJson(
-                  response.exchangeRates, response.subscription)
-              : null;
+          if (response is ExchangeRatesReceive) {
+            return ExchangeRatesResponse.fromJson(
+                response.exchangeRates, response.subscription);
+          } else {
+            throw Exception('Bad response received');
+          }
         },
       );
 

--- a/lib/api/response/exchange_rates_response_extended.dart
+++ b/lib/api/response/exchange_rates_response_extended.dart
@@ -2,8 +2,7 @@ import 'package:deriv_dependency_injector/dependency_injector.dart';
 import 'package:flutter_deriv_api/api/exceptions/base_api_exception.dart';
 import 'package:flutter_deriv_api/api/models/base_exception_model.dart';
 import 'package:flutter_deriv_api/api/response/exchange_rates_response_result.dart';
-import 'package:flutter_deriv_api/basic_api/generated/exchange_rates_receive.dart';
-import 'package:flutter_deriv_api/basic_api/generated/exchange_rates_send.dart';
+import 'package:flutter_deriv_api/basic_api/generated/api.dart';
 import 'package:flutter_deriv_api/basic_api/response.dart';
 import 'package:flutter_deriv_api/helpers/helpers.dart';
 import 'package:flutter_deriv_api/services/connection/api_manager/base_api.dart';
@@ -38,4 +37,18 @@ class ExchangeRatesResponseExtended extends ExchangeRatesResponse {
               : null;
         },
       );
+
+  /// unsubscribe from the subscribed exchange rates <br>
+  /// In case of error, It will throw [BaseAPIException].
+  static Future<bool> unsubscribeFromExchangeRates(
+      String subscriptionId) async {
+    final ForgetReceive response =
+        await _api.unsubscribe(subscriptionId: subscriptionId);
+    checkException(
+      response: response,
+      exceptionCreator: ({BaseExceptionModel? baseExceptionModel}) =>
+          BaseAPIException(baseExceptionModel: baseExceptionModel),
+    );
+    return response.forget!;
+  }
 }

--- a/lib/api/response/exchange_rates_response_extended.dart
+++ b/lib/api/response/exchange_rates_response_extended.dart
@@ -1,0 +1,41 @@
+import 'package:deriv_dependency_injector/dependency_injector.dart';
+import 'package:flutter_deriv_api/api/exceptions/base_api_exception.dart';
+import 'package:flutter_deriv_api/api/models/base_exception_model.dart';
+import 'package:flutter_deriv_api/api/response/exchange_rates_response_result.dart';
+import 'package:flutter_deriv_api/basic_api/generated/exchange_rates_receive.dart';
+import 'package:flutter_deriv_api/basic_api/generated/exchange_rates_send.dart';
+import 'package:flutter_deriv_api/basic_api/response.dart';
+import 'package:flutter_deriv_api/helpers/helpers.dart';
+import 'package:flutter_deriv_api/services/connection/api_manager/base_api.dart';
+import 'package:flutter_deriv_api/services/connection/call_manager/base_call_manager.dart';
+
+/// Extended functionality for [ExchangeRatesResponse] class.
+class ExchangeRatesResponseExtended extends ExchangeRatesResponse {
+  static final BaseAPI _api = Injector()<BaseAPI>();
+
+  /// This will subscribe to currency exchange.<br>
+  /// Inside [ExchangeRateRequest] class:
+  /// [baseCurrency]: currency that should be exchanged like USD, BTC or any other.
+  /// [targetCurrency]: currency that you want to exchange to.
+  /// Incase of error, It will throw [BaseAPIException].
+  static Stream<ExchangeRatesResponse?> subscribeToExchangeRates(
+    ExchangeRatesRequest request, {
+    RequestCompareFunction? comparePredicate,
+  }) =>
+      _api
+          .subscribe(request: request, comparePredicate: comparePredicate)!
+          .map<ExchangeRatesResponse?>(
+        (Response response) {
+          checkException(
+            response: response,
+            exceptionCreator: ({BaseExceptionModel? baseExceptionModel}) =>
+                BaseAPIException(baseExceptionModel: baseExceptionModel),
+          );
+
+          return response is ExchangeRatesReceive
+              ? ExchangeRatesResponse.fromJson(
+                  response.exchangeRates, response.subscription)
+              : null;
+        },
+      );
+}

--- a/lib/api/response/exchange_rates_response_result.dart
+++ b/lib/api/response/exchange_rates_response_result.dart
@@ -9,6 +9,7 @@ import 'package:flutter_deriv_api/basic_api/generated/exchange_rates_send.dart';
 import 'package:flutter_deriv_api/helpers/helpers.dart';
 import 'package:flutter_deriv_api/services/connection/api_manager/base_api.dart';
 import 'package:deriv_dependency_injector/dependency_injector.dart';
+import 'package:flutter_deriv_api/api/response/exchange_rates_response_extended.dart';
 
 /// Exchange rates response model class.
 abstract class ExchangeRatesResponseModel {
@@ -25,7 +26,10 @@ abstract class ExchangeRatesResponseModel {
   final Subscription? subscription;
 }
 
-/// Exchange rates response class.
+/// Exchange rates response class. <br>
+///
+/// DeveloperNote: In case of adding new functionality to this class, please use the extended version of the class i.e [ExchangeRatesResponseExtended]
+
 class ExchangeRatesResponse extends ExchangeRatesResponseModel {
   /// Initializes Exchange rates response class.
   const ExchangeRatesResponse({
@@ -88,6 +92,7 @@ class ExchangeRatesResponse extends ExchangeRatesResponseModel {
   ///
   /// For parameters information refer to [ExchangeRatesRequest].
   /// Throws an [BaseAPIException] if API response contains an error.
+  /// Developer NOTE: to use the realtime update to exchange rates please refer to [ExchangeRatesResponseExtended.subscribeToExchangeRates] method.
   static Future<ExchangeRates> fetchExchangeRates(
     ExchangeRatesRequest request,
   ) async {


### PR DESCRIPTION
This PR has extended the version of `ExchangeRatesResponse` to include subscription calls for real-time exchange rates.