### PR TITLE
refactor: set userAgent for HttpClient in case of proxyAwareConnection

### DIFF
--- a/lib/services/connection/api_manager/binary_api.dart
+++ b/lib/services/connection/api_manager/binary_api.dart
@@ -88,7 +88,9 @@ class BinaryAPI extends BaseAPI {
       final String proxy = await FlutterSystemProxy.findProxyFromEnvironment(
           uri.toString().replaceAll('wss', 'https'));
 
-      client = HttpClient()..findProxy = (Uri uri) => proxy;
+      client = HttpClient()
+        ..userAgent = WebSocket.userAgent
+        ..findProxy = (Uri uri) => proxy;
     }
 
     // Initialize connection to websocket server.
@@ -139,8 +141,10 @@ class BinaryAPI extends BaseAPI {
   }
 
   @override
-  Future<T> call<T>(
-      {required Request request, List<String> nullableKeys = const <String>[],}) async {
+  Future<T> call<T>({
+    required Request request,
+    List<String> nullableKeys = const <String>[],
+  }) async {
     final Response response = await (_callManager ??= CallManager(this))(
       request: request,
       nullableKeys: nullableKeys,


### PR DESCRIPTION
Backend are checking the user agent to store the device name creating the passkey, we are setting the correct user agent for WebSocket but not in the case where it's a proxy aware connection.